### PR TITLE
Use BSD-2-Clause license identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     name=name,
     version=get_version(package),
     url=url,
-    license=license,
+    license_expression=license,
     description=description,
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ description = "Resolve form field arguments dynamically when a form is instantia
 url = "https://github.com/dabapps/django-forms-dynamic"
 author = "DabApps"
 author_email = "hello@dabapps.com"
-license = "BSD"
+license = "BSD-2-Clause"
 
 with open("README.md") as f:
     readme = f.read()


### PR DESCRIPTION
`BSD` is ambiguous. Since the license is BSD 2 Clause, the [SPDX identifier](https://spdx.org/licenses/BSD-2-Clause.html) for this license can be used here.

